### PR TITLE
Activate mermeid extension

### DIFF
--- a/default-site.yml
+++ b/default-site.yml
@@ -27,11 +27,11 @@ antora:
   extensions:
     - require: ./content/lib/dev-mode.js
       enabled: true
-    # - require: '@sntke/antora-mermaid-extension'
-    #   mermaid_library_url: "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs" # <2>
-    #   script_stem: header-scripts
-    #   mermaid_initialize_options:
-    #     start_on_load: true
+    - require: '@sntke/antora-mermaid-extension'
+      mermaid_library_url: "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs" # <2>
+      script_stem: header-scripts
+      mermaid_initialize_options:
+        start_on_load: true
 
 
 output:


### PR DESCRIPTION
The extension needs to be activated in the site.yml, after being installed via npm install